### PR TITLE
remove unnecessary argument in behaviors

### DIFF
--- a/src/leiningen/new/lt_plugin/behaviors
+++ b/src/leiningen/new/lt_plugin/behaviors
@@ -1,2 +1,2 @@
-{:+ {:app [(:lt.objs.plugins/load-js "{{sanitized}}_compiled.js" true)]
+{:+ {:app [(:lt.objs.plugins/load-js "{{sanitized}}_compiled.js")]
      :{{name}}.hello [:lt.plugins.{{name}}/on-close-destroy]}}


### PR DESCRIPTION
`lt.objs.plugins/load-js` is unary. The second argument (`true`) is ignored.

https://github.com/LightTable/LightTable/blob/6ffe995111ebf831fcd269359dc1d7019762fee3/src/lt/objs/plugins.cljs#L542
