### PR TITLE
generate blank PLUGIN_compiled.js file...

### DIFF
--- a/src/leiningen/new/lt_plugin.clj
+++ b/src/leiningen/new/lt_plugin.clj
@@ -17,5 +17,6 @@
              desc
              ["src/lt/plugins/{{sanitized}}.cljs" (render "plug.cljs" data)]
              ["{{sanitized}}.behaviors" (render "behaviors" data)]
+             ["{{sanitized}}_compiled.js" ""]
              ["project.clj" (render "project" data)]
              [".gitignore" (render "gitignore" data)])))


### PR DESCRIPTION
...to avoid an error when loading a newly generated plugin. This should make the initial steps of developing a plugin a little less confusing, especially for first-time authors.
