### PR TITLE
[hotfix 0.0.1-1]: Added behavior to close panel to objects, else may be ...

### DIFF
--- a/src/leiningen/new/lt_plugin/plug.cljs
+++ b/src/leiningen/new/lt_plugin/plug.cljs
@@ -9,6 +9,7 @@
 
 (object/object* ::{{name}}.hello
                 :tags [:{{name}}.hello]
+                :behaviors [::on-close-destroy]
                 :name "{{name}}"
                 :init (fn [this]
                         (hello-panel this)))


### PR DESCRIPTION
...a long search for people until they fix. There is about 1 blog article on the entire web that explains how LT plugins work and that shows this correct place to add the behavior. So it's the Right Thing To Do &trade; to provide a working sample. Currently anyone unaware has to kill LT entirely to get rid of the tab.
