### PR TITLE
Develop

### DIFF
--- a/foo.zsh
+++ b/foo.zsh
@@ -1,0 +1,41 @@
+#!/usr/bin/env zsh
+
+# always ensure latest sync
+sudo pacman -Syy
+
+# =(...) creates a searchable tempfile in zsh (a bit like <(...))
+# first add all lines matching to the array variable
+: ${(@Af)=pacup::="$(ack '^linux' =(pacman -Qu))"}
+
+if [[ ${#pacup} -gt 0 ]]
+then
+    print -P "We have found the following %F{blue}${#pacup}%f packages in upgrade list:"
+    for pkg in ${pacup[@]}
+    do
+        local warr
+        : ${(A)=warr::=${(ws: :)pkg[@]}}
+        print -P "Package %F{cyan}${warr[1]}%f currently at version ${warr[2]} can be upgraded to ${warr[4]}"
+        unset warr
+    done
+
+    print -P 'You should probably answer the next question with "%F{green}Yes%f" unless these do not look like Linux kernel upgrades.'
+    print -P 'As a security measure, the boot partition is mounted as %F{red}read-only (ro)%f by default (/etc/fstab). This script will remount as read-write so the kernel upgrade will not fail on trying to save early bootspace (initramfs) to the partition.'
+    vared -p 'Remount /boot to read-write (rw) and continue upgrade?' -c tmp
+
+    pattern='^[Y|y].*'
+
+    if [[ $tmp =~ $pattern ]]
+    then
+        print -Pn 'Remounting /boot read-write enabled...'
+        sudo mount -o remount,rw /boot
+        print -P '[%F{green}DONE%f]'
+        print -P 'Starting with %F{yellow}full system upgrade%f of ArchLinux weee...'
+        sudo pacman -Syyu
+    fi
+    
+
+fi
+
+
+# vim: :ft=zsh:ai:et:sw=4:sts=4:ts=4:nu:
+

--- a/src/leiningen/new/lt_plugin.clj
+++ b/src/leiningen/new/lt_plugin.clj
@@ -1,6 +1,7 @@
 (ns leiningen.new.lt-plugin
   (:require [leiningen.new.templates :refer [renderer name-to-path ->files]]
-            [leiningen.core.main :as main]))
+            [leiningen.core.main :as main]
+            [clojure.string :refer [capitalize]]))
 
 (def render (renderer "lt-plugin"))
 
@@ -8,6 +9,7 @@
   "Generates a Light Table plugin skeleton project"
   [name & args]
   (let [data {:name name
+              :title (capitalize name)
               :sanitized (name-to-path name)}
         json? (and args (= "-j" (subs (first args) 0 2)))
         desc (if json? ["plugin.json" (render "json" data)]

--- a/src/leiningen/new/lt_plugin/edn
+++ b/src/leiningen/new/lt_plugin/edn
@@ -1,5 +1,5 @@
 {:name "{{sanitized}}"
- :version "0.0.1"
+ :version "0.1.0"
  :author ""
  :source ""
  :desc ""

--- a/src/leiningen/new/lt_plugin/edn
+++ b/src/leiningen/new/lt_plugin/edn
@@ -1,6 +1,6 @@
 {:name "{{sanitized}}"
  :version "0.1.0"
- :author ""
- :source ""
- :desc ""
+ :author "Rob Jentzema"
+ :source "https://github.com/clojens/"
+ :desc "(EXPERIMENTAL) Light Table plugin for .... <todo>"
  :behaviors "{{sanitized}}.behaviors"}

--- a/src/leiningen/new/lt_plugin/edn
+++ b/src/leiningen/new/lt_plugin/edn
@@ -1,6 +1,6 @@
 {:name "{{sanitized}}"
  :version "0.1.0"
  :author "Rob Jentzema"
- :source "https://github.com/clojens/"
- :desc "(EXPERIMENTAL) Light Table plugin for .... <todo>"
+ :source "https://github.com/clojens/lt-{{sanitized}}"
+ :desc "{{title}} Light Table IDE plugin designed to <???>"
  :behaviors "{{sanitized}}.behaviors"}

--- a/src/leiningen/new/lt_plugin/plug.cljs
+++ b/src/leiningen/new/lt_plugin/plug.cljs
@@ -1,7 +1,16 @@
 (ns lt.plugins.{{name}}
   (:require [lt.object :as object]
             [lt.objs.tabs :as tabs]
-            [lt.objs.command :as cmd])
+            [lt.objs.command :as cmd]
+            [lt.objs.files :as files]
+            [lt.objs.document :as doc]
+            [lt.objs.editor :as editor]
+            [lt.objs.plugins :as plugins]
+            [lt.objs.platform :as platform]
+            [lt.objs.sidebar.command :as scmd]
+            [lt.objs.editor.pool :as pool]
+            [clojure.string :as string]
+            [crate.binding :as bindings])
   (:require-macros [lt.macros :refer [defui behavior]]))
 
 (defui hello-panel [this]

--- a/src/leiningen/new/lt_plugin/plug.cljs
+++ b/src/leiningen/new/lt_plugin/plug.cljs
@@ -4,14 +4,30 @@
             [lt.objs.command :as cmd]
             [lt.objs.files :as files]
             [lt.objs.document :as doc]
+            [lt.objs.opener :as opener]
             [lt.objs.editor :as editor]
             [lt.objs.plugins :as plugins]
             [lt.objs.platform :as platform]
             [lt.objs.sidebar.command :as scmd]
             [lt.objs.editor.pool :as pool]
+            [lt.util.load :as load]
+            [lt.util.dom :as dom]
             [clojure.string :as string]
             [crate.binding :as bindings])
   (:require-macros [lt.macros :refer [defui behavior]]))
+
+(def plugin-data (plugins/by-name "{{name}}"))
+
+
+(defn safe-get-file
+  "Returns composed, absolute and valid (safe) path to a file system resource
+  (file/folder) located within the plugin root folder, elsewise throws error."
+  [s] {:pre [(string? s)]}
+   (let [cap (files/join (:dir plugin-data) s)]
+     (if (files/exists? cap) cap
+       (throw (js/Error. (str "Could not locate a file system resource (file or folder) at path '"
+                             cap "'. Please check for errors and see if the path exists."))))))
+
 
 (defui hello-panel [this]
   [:h1 "Hello from {{name}}"])
@@ -25,7 +41,7 @@
 
 (behavior ::on-close-destroy
           :triggers #{:close}
-          :desc "{{name}}: Close tab and tabset as well if last tab"
+          :desc "{{title}}: Close tab and tabset as well if last tab"
           :reaction (fn [this]
                       (when-let [ts (:lt.objs.tabs/tabset @this)]
                         (when (= (count (:objs @ts)) 1)
@@ -35,6 +51,6 @@
 (def hello (object/create ::{{name}}.hello))
 
 (cmd/command {:command ::say-hello
-              :desc "{{name}}: Say Hello"
+              :desc "{{title}}: Say Hello"
               :exec (fn []
                       (tabs/add-or-focus! hello))})

--- a/src/leiningen/new/lt_plugin/project
+++ b/src/leiningen/new/lt_plugin/project
@@ -1,2 +1,2 @@
-(defproject {{name}} "0.0.1"
+(defproject {{name}} "0.1.0"
   :dependencies [[org.clojure/clojure "1.5.1"]])

--- a/src/leiningen/new/lt_plugin/project
+++ b/src/leiningen/new/lt_plugin/project
@@ -1,2 +1,5 @@
 (defproject {{name}} "0.1.0"
-  :dependencies [[org.clojure/clojure "1.5.1"]])
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                 [lein-light-nrepl "0.1.0"]]
+  :repl-options {:nrepl-middleware [lighttable.nrepl.handler/lighttable-ops]}
+  )


### PR DESCRIPTION
Semantic version [documentation](http://semver.org/) states pattern of `major.minor.patch`. This is a mistake sometimes made by people, to start at `0.0.1` although once you thought about it for two seconds (more apps do not do this correctly btw, others do) it makes sense:
- what is version 0 we are patching? 0 is nothing, non-existing release - and conversely
- how would one patch the version 0? this would require inclusion of yet another field or `-alpha` etc

Hence first released version should be `0.1.0` so we can patch that as `0.1.1` and `0.1.2` and so on
